### PR TITLE
nanobind speed up over pybind11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,16 +1,37 @@
-cmake_minimum_required(VERSION 3.15...3.22)
-
+cmake_minimum_required(VERSION 3.18...3.22)
 project(kepler LANGUAGES C CXX)
-if(SKBUILD)
-  execute_process(
-    COMMAND "${PYTHON_EXECUTABLE}" -c
-            "import pybind11; print(pybind11.get_cmake_dir())"
-    OUTPUT_VARIABLE _tmp_dir
-    OUTPUT_STRIP_TRAILING_WHITESPACE COMMAND_ECHO STDOUT)
-  list(APPEND CMAKE_PREFIX_PATH "${_tmp_dir}")
+
+if (NOT SKBUILD)
+  message(WARNING "This CMake file should be executed via scikit-build. "
+                  "Please run\n$ pip install .")
 endif()
 
-find_package(pybind11 CONFIG REQUIRED)
-pybind11_add_module(_core MODULE src/lib/main.cpp)
+
+if (SKBUILD)
+  # Constrain FindPython to find the Python version used by scikit-build
+  set(Python_VERSION "${PYTHON_VERSION_STRING}")
+  set(Python_EXECUTABLE "${PYTHON_EXECUTABLE}")
+  set(Python_INCLUDE_DIR "${PYTHON_INCLUDE_DIR}")
+  set(Python_LIBRARIES "${PYTHON_LIBRARY}")
+elseif (MSVC)
+  # MSVC needs a little extra help finding the Python library
+  find_package(PythonInterp)
+  find_package(Python)
+endif()
+
+find_package(Python COMPONENTS Interpreter Development.Module REQUIRED)
+
+# Run `nanobind.cmake_dir()` from Python to detect install location
+execute_process(
+  COMMAND
+  "${PYTHON_EXECUTABLE}" -c "import nanobind; print(nanobind.cmake_dir())"
+  OUTPUT_VARIABLE _tmp_dir
+  OUTPUT_STRIP_TRAILING_WHITESPACE COMMAND_ECHO STDOUT)
+list(APPEND CMAKE_PREFIX_PATH "${_tmp_dir}")
+
+# Now import nanobind from CMake
+find_package(nanobind CONFIG REQUIRED)
+
+nanobind_add_module(_core NB_STATIC src/lib/main.cpp)
 target_compile_definitions(_core PRIVATE VERSION_INFO=${PROJECT_VERSION})
-install(TARGETS _core DESTINATION .)
+install(TARGETS _core LIBRARY DESTINATION .)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ requires = [
     "setuptools>=61.0",
     "wheel",
     "setuptools_scm",
-    "pybind11>=2.6",
+    "nanobind",
     "scikit-build",
     "cmake",
     "ninja; platform_system!='Windows'",

--- a/src/lib/main.cpp
+++ b/src/lib/main.cpp
@@ -1,9 +1,9 @@
-#include <pybind11/numpy.h>
-#include <pybind11/pybind11.h>
+// #include <nanobind/numpy.h>
+#include <nanobind/nanobind.h>
 
 #include <cmath>
 
-namespace py = pybind11;
+namespace nb = nanobind;
 
 #ifndef M_PI
 #define M_PI 3.14159265358979323846264338328
@@ -102,7 +102,7 @@ double solve(double M, double ecc) {
 
 }  // namespace kepler
 
-PYBIND11_MODULE(_core, m) {
-  m.doc() = "A fast and stable Kepler solver";
-  m.def("solve", py::vectorize(kepler::solve));
+NB_MODULE(_core, m) {
+  // m.doc() = "A fast and stable Kepler solver";
+  m.def("solve", kepler::solve);
 }


### PR DESCRIPTION
Hi Dan, I've been playing around with [nanobind](https://github.com/wjakob/nanobind) as an alternative to pybind11 and tested it out on this awesome package. I've done some basic profiling and the speed-up is impressive:
<img width="659" alt="Screen Shot 2022-09-22 at 1 56 43 PM" src="https://user-images.githubusercontent.com/38233719/191871031-2ca66294-16cb-4d50-b587-28aca7826d10.png">

I'm opening this PR only to suggest a possible switch to `nanobind` in the future, when it becomes more stable. `nanobind` is only compatible with Python 3.8+ currently and it took some hacks to get it running on my M1 laptop. 